### PR TITLE
Cache timeout tests often fail.

### DIFF
--- a/tests/contrib/cache/test_cache.py
+++ b/tests/contrib/cache/test_cache.py
@@ -126,9 +126,9 @@ class GenericCacheTests(CacheTestsBase):
     def test_generic_timeout(self, c, fast_sleep):
         c.set('foo', 'bar', 0)
         assert c.get('foo') == 'bar'
-        c.set('baz', 'qux', 1)
+        c.set('baz', 'qux', 10)
         assert c.get('baz') == 'qux'
-        fast_sleep(3)
+        fast_sleep(13)
         # timeout of zero means no timeout
         assert c.get('foo') == 'bar'
         if self._guaranteed_deletes:


### PR DESCRIPTION
1. We currently use virtual machine as CI environment. It runs too
slowly, causing timeout-related tests to fail easily. will we consider
using docker as CI environment?
2. We can set the cache item's timeout to a large value.Since we have
`fast_sleep`, don't worry about waiting for a long time until cache item
expired.